### PR TITLE
chore(fixtures): refactor test fixture to associate them to types and derive them from seedData

### DIFF
--- a/src/graph/fixtures.ts
+++ b/src/graph/fixtures.ts
@@ -29,10 +29,7 @@ export const seedDataRest: MockListItemObject = Object.freeze({
   top_image_url: 'https://test.com/image.jpg',
 });
 
-export type SavedItemFragment = Omit<
-  GraphSavedItemEdge['node'],
-  'item'
->;
+export type SavedItemFragment = Omit<GraphSavedItemEdge['node'], 'item'>;
 export const mockSavedItemFragment: SavedItemFragment = {
   __typename: 'SavedItem',
   id: '1',

--- a/src/graph/fixtures.ts
+++ b/src/graph/fixtures.ts
@@ -3,56 +3,100 @@ import {
   SavedItemStatus,
   Videoness,
 } from '../generated/graphql/types';
-import { ListItemObject, RestResponse } from './types';
+import { GraphSavedItemEdge, ListItemObject, RestResponse } from './types';
+export const seedDataRest: MockListItemObject = Object.freeze({
+  ids: ['1', '2'],
+  given_url: 'https://test.com',
+  given_title: 'title',
+  favorite: '1',
+  status: '0',
+  time_added: '1677818995',
+  time_updated: '1677818995',
+  time_read: '1677818995',
+  time_favorited: '1677818995',
+  resolved_title: 'title',
+  resolved_url: 'https://test.com',
+  title: 'title',
+  excerpt: 'excerpt',
+  is_article: '1',
+  is_index: '1',
+  has_video: '1',
+  has_image: '1',
+  word_count: '100',
+  lang: 'en',
+  time_to_read: 10,
+  amp_url: 'https://test.com',
+  top_image_url: 'https://test.com/image.jpg',
+});
 
-export const testSavedItemFragment = (id) => {
+export type SavedItemFragment = Pick<
+  GraphSavedItemEdge['node'],
+  | '__typename'
+  | 'id'
+  | 'status'
+  | 'url'
+  | 'isFavorite'
+  | 'isArchived'
+  | '_createdAt'
+  | '_updatedAt'
+  | 'favoritedAt'
+  | 'archivedAt'
+>;
+export const mockSavedItemFragment: SavedItemFragment = {
+  __typename: 'SavedItem',
+  id: '1',
+  status: SavedItemStatus.Unread,
+  url: seedDataRest.given_url,
+  isFavorite: seedDataRest.favorite === '1',
+  isArchived: true, //todo: map status to archived
+  _createdAt: parseInt(seedDataRest.time_added),
+  _updatedAt: parseInt(seedDataRest.time_updated),
+  favoritedAt: parseInt(seedDataRest.time_favorited),
+  archivedAt: parseInt(seedDataRest.time_read),
+};
+export type ItemFragment = GraphSavedItemEdge['node']['item'];
+export const mockItemFragment: ItemFragment = {
+  __typename: 'Item',
+  itemId: `item-${seedDataRest.ids[0]}`,
+  resolvedId: `resolved-${seedDataRest.ids[0]}`,
+  wordCount: parseInt(seedDataRest.word_count),
+  title: seedDataRest.title,
+  timeToRead: seedDataRest.time_to_read,
+  resolvedUrl: seedDataRest.resolved_url,
+  givenUrl: seedDataRest.given_url,
+  excerpt: seedDataRest.excerpt,
+  domain: 'test.com', // mock to seedDataRest when needed
+  isArticle: seedDataRest.is_article === '1',
+  isIndex: seedDataRest.is_index === '1',
+  hasVideo: Videoness.HasVideos,
+  hasImage: Imageness.HasImages,
+  language: seedDataRest.lang,
+  ampUrl: seedDataRest.amp_url,
+  topImage: {
+    url: seedDataRest.top_image_url,
+  },
+};
+
+export const testSavedItemFragment = (
+  mockInput: SavedItemFragment = mockSavedItemFragment
+): SavedItemFragment => {
+  return mockInput;
+};
+
+export const testItemFragment = (mockInput: {
+  itemId: string;
+  __typename: 'PendingItem' | 'Item';
+}): ItemFragment => {
   return {
-    id: id,
-    status: SavedItemStatus.Unread,
-    url: 'test.com',
-    isFavorite: true,
-    isArchived: true,
-    _createdAt: 1677818995,
-    _updatedAt: 1677818995,
-    favoritedAt: 1677818995,
-    archivedAt: 1677818995,
-    //can inject tagModel as parameter when mocking
-    tags: [
-      {
-        id: `tag-${id}-1`,
-        name: 'tag-name-1',
-      },
-      {
-        id: `tag-${id}-2`,
-        name: 'tag-name-2',
-      },
-    ],
+    ...mockItemFragment,
+    itemId: mockInput.itemId,
+    resolvedId: `resolved-${mockInput.itemId}`,
   };
 };
 
-export const testItemFragment = (id) => {
-  return {
-    itemId: `item-${id}`,
-    resolvedId: `resolved-${id}`,
-    wordCount: 100,
-    title: 'title',
-    timeToRead: 10,
-    resolvedUrl: 'https://test.com',
-    givenUrl: 'https://test.com',
-    excerpt: 'excerpt',
-    domain: 'test.com',
-    isArticle: true,
-    isIndex: true,
-    hasVideo: Videoness.HasVideos,
-    hasImage: Imageness.HasImages,
-    language: 'en',
-    ampUrl: 'https://test.com',
-    topImage: {
-      url: 'https://test.com/image.jpg',
-    },
-  };
+type MockListItemObject = Omit<ListItemObject, 'item_id' | 'resolved_id'> & {
+  ids: string[];
 };
-
 /**
  * return REST v3 GET response for given Ids
  * //todo: need to include tags, images, videoes etc
@@ -60,39 +104,40 @@ export const testItemFragment = (id) => {
  * @param ids
  */
 export const testV3GetResponse = (
-  ids: string[],
-  time_added?: string,
-  time_updated?: string
+  mockInputs: MockListItemObject = {
+    ...seedDataRest,
+  }
 ): RestResponse => {
   const map: { [key: string]: ListItemObject } = {};
-  ids.forEach((id) => {
+
+  mockInputs.ids.forEach((id) => {
     map[id] = {
       item_id: id,
       resolved_id: `resolved-${id}`,
-      given_url: 'https://test.com',
-      given_title: 'title',
-      favorite: '1',
-      status: '0',
-      //can add more test injection as we work on tickets
-      time_added: time_added ?? '1677818995',
-      time_updated: time_updated ?? '1677818995',
-      time_read: '1677818995',
-      time_favorited: '1677818995',
-      resolved_title: 'title',
-      resolved_url: 'https://test.com',
-      title: 'title',
-      excerpt: 'excerpt',
-      is_article: '1',
-      is_index: '1',
-      has_video: '1',
-      has_image: '1',
-      word_count: '100',
-      lang: 'en',
-      time_to_read: 10,
-      amp_url: 'https://test.com',
-      top_image_url: 'https://test.com/image.jpg',
+      title: mockInputs.title,
+      given_title: mockInputs.given_title,
+      given_url: mockInputs.given_url,
+      favorite: mockInputs.favorite,
+      status: mockInputs.status,
+      time_added: mockInputs.time_added,
+      time_updated: mockInputs.time_updated,
+      time_read: mockInputs.time_read,
+      time_favorited: mockInputs.time_favorited,
+      resolved_title: mockInputs.resolved_title,
+      resolved_url: mockInputs.resolved_url,
+      excerpt: mockInputs.excerpt,
+      is_article: mockInputs.is_article,
+      is_index: mockInputs.is_index,
+      has_video: mockInputs.has_video,
+      has_image: mockInputs.has_image,
+      word_count: mockInputs.word_count,
+      lang: mockInputs.lang,
+      time_to_read: mockInputs.time_to_read,
+      amp_url: mockInputs.amp_url,
+      top_image_url: mockInputs.top_image_url,
     };
   });
+
   return {
     cacheType: 'db',
     list: map,

--- a/src/graph/fixtures.ts
+++ b/src/graph/fixtures.ts
@@ -29,18 +29,9 @@ export const seedDataRest: MockListItemObject = Object.freeze({
   top_image_url: 'https://test.com/image.jpg',
 });
 
-export type SavedItemFragment = Pick<
+export type SavedItemFragment = Omit<
   GraphSavedItemEdge['node'],
-  | '__typename'
-  | 'id'
-  | 'status'
-  | 'url'
-  | 'isFavorite'
-  | 'isArchived'
-  | '_createdAt'
-  | '_updatedAt'
-  | 'favoritedAt'
-  | 'archivedAt'
+  'item'
 >;
 export const mockSavedItemFragment: SavedItemFragment = {
   __typename: 'SavedItem',

--- a/src/graph/fixtures.ts
+++ b/src/graph/fixtures.ts
@@ -77,12 +77,23 @@ export const mockItemFragment: ItemFragment = {
   },
 };
 
+/**
+ * function to return saved item fragment
+ * used default mockSavedItemFragment if values are not added explicitly
+ * @param mockInput mock saved item fragment
+ */
 export const testSavedItemFragment = (
   mockInput: SavedItemFragment = mockSavedItemFragment
 ): SavedItemFragment => {
   return mockInput;
 };
 
+/**
+ * function to return test Item fragment
+ * used default mockItemFragment if values are not added explicitly
+ * todo: refactor mockInput types as you add more fields other than itemIds
+ * @param mockInput necessary inputs required for populating mock Item
+ */
 export const testItemFragment = (mockInput: {
   itemId: string;
   __typename: 'PendingItem' | 'Item';

--- a/src/graph/queries/savedItems.graphql
+++ b/src/graph/queries/savedItems.graphql
@@ -13,10 +13,6 @@ query getSavedItems($pagination: PaginationInput, $filters: SavedItemsFilter, $s
                     _createdAt
                     favoritedAt
                     archivedAt
-                    tags {
-                        id
-                        name
-                    }
                     item {
                         __typename
                         ... on Item {

--- a/src/graph/toGraphQL.spec.ts
+++ b/src/graph/toGraphQL.spec.ts
@@ -1,0 +1,26 @@
+//add unit test for input type mapping
+import { setSaveInputsFromGetCall } from './toGraphQL';
+import {
+  SavedItemsSortBy,
+  SavedItemsSortOrder,
+  SavedItemStatusFilter,
+} from '../generated/graphql/types';
+
+describe('toGraphQL', () => {
+  //todo: refactor this test as you refactor the method
+  it('should map saves input', () => {
+    const expected = {
+      pagination: {
+        first: 10,
+      },
+      sort: {
+        sortBy: SavedItemsSortBy.UpdatedAt,
+        sortOrder: SavedItemsSortOrder.Asc,
+      },
+      filter: {
+        status: SavedItemStatusFilter.Unread,
+      },
+    };
+    expect(setSaveInputsFromGetCall('sample-rest-params')).toEqual(expected);
+  });
+});

--- a/src/graph/toRest.spec.ts
+++ b/src/graph/toRest.spec.ts
@@ -5,6 +5,9 @@ import {
   testV3GetResponse,
   testItemFragment,
   testSavedItemFragment,
+  mockSavedItemFragment,
+  seedDataRest,
+  mockItemFragment,
 } from './fixtures';
 
 describe('convertSavedItemsToRestResponse', () => {
@@ -17,10 +20,15 @@ describe('convertSavedItemsToRestResponse', () => {
               cursor: 'some-cursor',
               node: {
                 __typename: 'SavedItem',
-                ...testSavedItemFragment('id1'),
+                ...testSavedItemFragment({
+                  ...mockSavedItemFragment,
+                  id: `id1`,
+                }),
                 item: {
-                  __typename: 'Item',
-                  ...testItemFragment(`id1`),
+                  ...testItemFragment({
+                    ...mockItemFragment,
+                    itemId: `id1`,
+                  }),
                 },
               },
             },
@@ -28,10 +36,15 @@ describe('convertSavedItemsToRestResponse', () => {
               cursor: 'some-cursor-2',
               node: {
                 __typename: 'SavedItem',
-                ...testSavedItemFragment('id2'),
+                ...testSavedItemFragment({
+                  ...mockSavedItemFragment,
+                  id: `id2`,
+                }),
                 item: {
-                  __typename: 'Item',
-                  ...testItemFragment(`id2`),
+                  ...testItemFragment({
+                    ...mockItemFragment,
+                    itemId: `id2`,
+                  }),
                 },
               },
             },
@@ -41,7 +54,10 @@ describe('convertSavedItemsToRestResponse', () => {
     };
 
     expect(convertSavedItemsToRestResponse(graphResponse)).toEqual(
-      testV3GetResponse(['id1', 'id2'])
+      testV3GetResponse({
+        ...seedDataRest,
+        ids: ['id1', 'id2'],
+      })
     );
   });
 
@@ -55,7 +71,10 @@ describe('convertSavedItemsToRestResponse', () => {
               cursor: 'some-cursor',
               node: {
                 __typename: 'SavedItem',
-                ...testSavedItemFragment(`id1`),
+                ...testSavedItemFragment({
+                  ...mockSavedItemFragment,
+                  id: `id1`,
+                }),
                 item: {
                   __typename: 'PendingItem',
                 },


### PR DESCRIPTION
## Goal
- set unit test pattern for future tickets
- test fixtures are associated with our types used in code and derived from generated types
- minimize use of literals and have them derived from the frozen seedData as much as possible

### scope:
- refactor existing fixture and unit test

Ticket: no_ticket
follow up refactoring from this PR: https://pocket.slack.com/archives/C034FB364LC/p1677866833799359 discussion

- [x] [dev testing done](https://pocket-dev.postman.co/workspace/Pocket~5b389395-697a-44ae-bcfd-3ff592fd249c/example/16399619-8c8ab5b0-bf6e-44a9-9403-37ccd990ac52)