### PR TITLE
fix(GET): fetch tokens from params for GET request

### DIFF
--- a/src/routes/v3Get.ts
+++ b/src/routes/v3Get.ts
@@ -12,10 +12,10 @@ const router: Router = Router();
 
 router.get('/', async (req: Request, res: Response) => {
   try {
-    const variables = setSaveInputsFromGetCall(req.params);
+    const variables = setSaveInputsFromGetCall(req.query);
     const headers = req.headers;
-    const accessToken = (req.body.access_token as string) ?? null;
-    const consumerKey = (req.body.consumer_key as string) ?? null;
+    const accessToken = (req.query.access_token as string) ?? null;
+    const consumerKey = (req.query.consumer_key as string) ?? null;
     return res.json(
       await processV3call(accessToken, consumerKey, headers, variables)
     );


### PR DESCRIPTION
## Goal
 follows web-repo request pattern: fetch tokens from query params for GET request instead of body,

https://pocket-dev.postman.co/workspace/Pocket~5b389395-697a-44ae-bcfd-3ff592fd249c/request/16399619-66415977-d2f8-426b-b3c3-e92321ee1bab

ticket: https://getpocket.atlassian.net/browse/INFRA-1212